### PR TITLE
Test image artifacts added to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,3 +51,64 @@ jobs:
         run: |
 
           nox --session test --no-install --reuse-existing-virtualenvs
+
+  create-image-artifacts-if-test-failed:
+    needs: test
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git to use https
+        run: git config --global hub.protocol https
+
+      - name: Install Conda environment with Micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: jupysql-plugin
+          environment-file: environment.yml
+
+      - name: Set up environment variables
+        env:
+          REUSE_EXISTING_SERVER: true
+        run: |
+          echo "REUSE_EXISTING_SERVER=$REUSE_EXISTING_SERVER" >> $GITHUB_ENV
+
+      - name: Install JupySQL-Plugin
+        run: |
+          pip install -e "."
+
+      - name: Install Galata
+        run: |
+          yarn playwright install chromium
+        working-directory: ui-tests
+
+      - name: Launch JupyterLab
+        run: yarn run start:detached
+        working-directory: ui-tests
+
+      - name: Wait for JupyterLab
+        uses: ifaxity/wait-on-action@v1
+        with:
+          resource: http-get://localhost:8888/api
+          timeout: 20000
+
+      - name: Generate updated Galata References
+        run: yarn run test:update
+        working-directory: ui-tests
+
+      - name: Compress snapshots
+        run: |
+          sudo apt install optipng
+          optipng *.png
+        working-directory: ui-tests/tests/jupysql_plugin.test.ts-snapshots
+
+      - name: Upload test snapshots
+        uses: actions/upload-artifact@v3
+        with:
+          name: snapshots
+          path: ui-tests/tests/jupysql_plugin.test.ts-snapshots

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
     "name": "jupysql-plugin",
     "version": "0.1.4",
     "description": "Jupyterlab extension for JupySQL",
+    "private": true,
     "keywords": [
         "jupyter",
         "jupyterlab",
@@ -27,6 +28,12 @@
         "type": "git",
         "url": "https://github.com/ploomber/jupysql-plugin.git.git"
     },
+    "workspaces": {
+        "packages": [
+          "jupysql_plugin",
+          "ui-tests"
+        ]
+      },
     "scripts": {
         "build": "jlpm build:lib && jlpm build:labextension:dev",
         "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",

--- a/ui-tests/package.json
+++ b/ui-tests/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "scripts": {
     "start": "jupyter lab --config jupyter_server_test_config.py",
+    "start:detached": "yarn run start&",
     "test": "jlpm playwright test",
     "test:update": "jlpm playwright test --update-snapshots"
   },

--- a/ui-tests/playwright.config.js
+++ b/ui-tests/playwright.config.js
@@ -9,6 +9,6 @@ module.exports = {
     command: 'jlpm start',
     url: 'http://localhost:8888/lab',
     timeout: 120 * 1000,
-    reuseExistingServer: !process.env.CI
+    reuseExistingServer: process.env.REUSE_EXISTING_SERVER || !process.env.CIT
   }
 };


### PR DESCRIPTION
Uploads test images as artifacts when CI fails.

## Artifacts location:
At the bottom of the workflow summary page, there is a dedicated section for artifacts with a directory you can download called `snapshots`.

![image](https://github.com/ploomber/jupysql-plugin/assets/103026689/3ac0ad5e-5e0b-4f7f-9b31-229f614164f1)

For more information about the 'upload-artifact' feature, please refer to the [documentation](https://github.com/actions/upload-artifact).

Issue: #28 