### PR TITLE
connector widget improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.2.1
+
+* Connector widget creates parent directories if needed
+* Connector widget sets the default alias as "default" if the `.ini` file has no connections
+
 ## 0.2.0
 
 * Updates "Deploy Notebook" endpoint

--- a/jupysql_plugin/widgets/connections.py
+++ b/jupysql_plugin/widgets/connections.py
@@ -1,4 +1,5 @@
 from configparser import ConfigParser
+from pathlib import Path
 
 
 try:
@@ -39,7 +40,12 @@ def _store_connection_details(connection_name, fields):
         if fields[field]:
             config.set(connection_name, field, fields[field])
 
-    with open(get_path_to_config_file(), "w") as config_file:
+    path_to_config_file = Path(get_path_to_config_file())
+
+    if not path_to_config_file.parent.exists():
+        path_to_config_file.parent.mkdir(parents=True)
+
+    with open(path_to_config_file, "w") as config_file:
         config.write(config_file)
 
 

--- a/src/widgets/connector.ts
+++ b/src/widgets/connector.ts
@@ -317,19 +317,33 @@ export class ConnectorView extends DOMWidgetView {
         connectionFormContainer.appendChild(connectionForm)
 
         fields.forEach(field => {
+            // text description
             const fieldContainer = document.createElement("DIV");
             fieldContainer.className = "field-container";
             const label = <HTMLLabelElement>document.createElement("LABEL");
             label.setAttribute("for", field.id);
             label.innerHTML = field.label;
+
+            // form value
             const input = <HTMLInputElement>document.createElement("INPUT");
             input.id = field.id;
             input.name = field.id;
             input.className = "field";
 
-            if (field.default !== undefined) {
+            console.log("field", field, this.connections.length)
+
+            // when creating the connection alias field, set the default value
+            // to "default" if there are no connections, this will ensure that
+            // the notebook automatically reconnects to the database if the
+            // kernel is restarted
+            if (field.id == "connectionName" && this.connections.length === 0) {
+                input.value = "default"
+
+                // otherwise, set the default value if there's one
+            } else if (field.default !== undefined) {
                 input.value = field.default;
             }
+
 
             input.setAttribute("type", field.type);
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,7 +14,7 @@ def _init_sql_magic():
     shell = InteractiveShell()
     sql_magic = SqlMagic(shell)
 
-    # set the default dsn filename to odbc.ini so we don't read from the home directory
+    # change the default dsn filename so we don't read from the home directory
     sql_magic.dsn_filename = "jupysql-plugin.ini"
     _set_sql_magic(sql_magic)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,14 +7,18 @@ from IPython import InteractiveShell
 from sql.magic import SqlMagic, _set_sql_magic
 from sql import connection
 
-# currently the connection widget loads the config when importing the module
-# so we need to ensure the magic is initialized before importing the widget
-shell = InteractiveShell()
-sql_magic = SqlMagic(shell)
 
-# set the default dsn filename to odbc.ini so we don't read from the home directory
-sql_magic.dsn_filename = "jupysql-plugin.ini"
-_set_sql_magic(sql_magic)
+def _init_sql_magic():
+    # currently the connection widget loads the config when importing the module
+    # so we need to ensure the magic is initialized before importing the widget
+    shell = InteractiveShell()
+    sql_magic = SqlMagic(shell)
+
+    # set the default dsn filename to odbc.ini so we don't read from the home directory
+    sql_magic.dsn_filename = "jupysql-plugin.ini"
+    _set_sql_magic(sql_magic)
+
+    return sql_magic
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -25,6 +29,8 @@ def isolate_tests(monkeypatch):
 
     Also clear up any stored snippets.
     """
+    _init_sql_magic()
+
     # reset connections
     connections = {}
     monkeypatch.setattr(connection.ConnectionManager, "connections", connections)
@@ -47,3 +53,8 @@ def tmp_empty(tmp_path):
     os.chdir(str(tmp_path))
     yield str(Path(tmp_path).resolve())
     os.chdir(old)
+
+
+@pytest.fixture
+def override_sql_magic():
+    yield _init_sql_magic()

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -45,3 +45,29 @@ def test_create_new_connection(tmp_empty, data, expected):
     connections._create_new_connection(data)
     content = Path("jupysql-plugin.ini").read_text()
     assert content == expected
+
+
+@pytest.mark.parametrize(
+    "dsn_filename",
+    [
+        "jupysql-plugin.ini",
+        "path/to/jupysql-plugin.ini",
+    ],
+    ids=[
+        "default",
+        "nested",
+    ],
+)
+def test_store_connection_details(tmp_empty, override_sql_magic, dsn_filename):
+    override_sql_magic.dsn_filename = dsn_filename
+
+    connections._store_connection_details("some_connection", {"drivername": "duckdb"})
+
+    assert (
+        Path(dsn_filename).read_text()
+        == """\
+[some_connection]
+drivername = duckdb
+
+"""
+    )


### PR DESCRIPTION
## Describe your changes

- connector widget creates parent directories if needed
- storing the first connection as "default" so jupyter automatically connects to it when restarting the kernel

## Issue number

Closes https://github.com/ploomber/jupysql-plugin/issues/65

## Checklist before requesting a review

- [ ] Performed a self-review of my code
- [ ] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [ ] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [ ] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)
