### PR TITLE
54 connector widget special chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## 0.2.5
 
 * Automatically activate server extension
+* Fixed error that broke `Delete` and `Connect` buttons on the Connector Widget
+when special characters were included in the connection alias
 
 ## 0.2.4
 

--- a/src/utils/helper-functions.ts
+++ b/src/utils/helper-functions.ts
@@ -5,7 +5,6 @@
  * @returns Input string with special characters replaced with 
  *          their ASCII values.
  */
-
 export const specialToASCII = (str: string): string => {
     let res = '';
     for(let i = 0; i < str.length; i++) {

--- a/src/utils/helper-functions.ts
+++ b/src/utils/helper-functions.ts
@@ -1,3 +1,11 @@
+/**
+ * Convert special characters to their ASCII number values.
+ * 
+ * @param str Input string to be processed.
+ * @returns Input string with special characters replaced with 
+ *          their ASCII values.
+ */
+
 export const specialToASCII = (str: string): string => {
     let res = '';
     for(let i = 0; i < str.length; i++) {

--- a/src/utils/helper-functions.ts
+++ b/src/utils/helper-functions.ts
@@ -1,0 +1,15 @@
+export const specialToASCII = (str: string): string => {
+    let res = '';
+    for(let i = 0; i < str.length; i++) {
+        if(+str[i] || str[i].toLowerCase() !== str[i].toUpperCase()){
+            res += str[i];
+            continue;
+        }
+        else if (str[i] === ' ') {
+            res += '_';
+            continue;
+        }
+        res += str[i].charCodeAt(0);
+    };
+    return res;
+ };

--- a/src/widgets/connector.ts
+++ b/src/widgets/connector.ts
@@ -6,6 +6,7 @@ import {
 
 import { MODULE_NAME, MODULE_VERSION } from '../version';
 
+import { specialToASCII } from '../utils/helper-functions';
 
 // Import the CSS
 import '../../style/connector.css';
@@ -155,7 +156,7 @@ export class ConnectorView extends DOMWidgetView {
         // Draw connection buttons
         connections.forEach((connection: Connection) => {
             const { name } = connection;
-            const name_without_spaces = name.replace(/ /g, "_");
+            const name_without_spaces = specialToASCII(name)
 
             const buttonContainer = document.createElement("DIV");
             buttonContainer.className = "connection-button-container";
@@ -339,7 +340,7 @@ export class ConnectorView extends DOMWidgetView {
         deleteConnectionMessage.querySelector(".actions").appendChild(deleteButton);
 
         // hide controllers
-        const deleteConnBtn = this.el.querySelector(`#deleteConnBtn_${connection["name"].replace(/ /g, "_")}`);
+        const deleteConnBtn = this.el.querySelector(`#deleteConnBtn_${specialToASCII(connection["name"])}`);
         const actionsContainer = <HTMLElement>deleteConnBtn.parentNode;
         actionsContainer.style.display = "none"
 
@@ -635,7 +636,7 @@ export class ConnectorView extends DOMWidgetView {
                 buttonEl.classList.add("secondary");
             });
 
-        const selectedButtonEl = (<HTMLButtonElement>this.el.querySelector(`#connBtn_${connectionName.replace(/ /g, "_")}`));
+        const selectedButtonEl = (<HTMLButtonElement>this.el.querySelector(`#connBtn_${specialToASCII(connectionName)}`));
         selectedButtonEl.innerText = "Connected";
         selectedButtonEl.classList.add("primary");
     }

--- a/ui-tests/tests/widget.test.ts
+++ b/ui-tests/tests/widget.test.ts
@@ -662,6 +662,8 @@ const specialAliases = [
 
 for (const {alias, id} of specialAliases) {
   test(`test delete button for aliases with special chars: ${alias}`, async ({ page }) => {
+    await displayWidget(page);
+
     // create a new connection
     await page.locator('#createNewConnection').click();
     await page.locator('#connectionName').fill(alias);
@@ -682,7 +684,7 @@ for (const {alias, id} of specialAliases) {
     await createDefaultConnection(page);
 
     // create a new connection
-    await page.locator('#createNewConnectiton').click();
+    await page.locator('#createNewConnection').click();
     await page.locator('#connectionName').fill(alias);
     await page.locator('#createConnectionFormButton').click();
 

--- a/ui-tests/tests/widget.test.ts
+++ b/ui-tests/tests/widget.test.ts
@@ -645,3 +645,51 @@ test('test error if edit connection with existing name', async ({ page }) => {
 
     await expect(page.locator('.user-error-message')).toContainText("A connection named 'default' already exists in your connections file");
 });
+
+const specialAliases = [
+  {alias: 'db', id: 'id'},
+  {alias: 'db with space', id: 'db_with_space'},
+  {alias: 'db?', id: 'db63'},
+  {alias: 'db://', id: 'db584747'},
+  {alias: 'db! !', id: 'db33_33'},
+  {alias: ';db', id: '59db'},
+  {alias: ' db', id: '_db'},
+  { 
+    alias: '!@#$%^&*()-_[]{}|;:?<>,./', 
+    id: '33643536379438424041459591931231251245958636062444647'
+  },
+]
+
+for (const {alias, id} of specialAliases) {
+  test(`test delete button for aliases with special chars`, async ({ page }) => {
+    // create a new connection
+    await page.locator('#createNewConnection').click();
+    await page.locator('#connectionName').fill(alias);
+    await page.locator('#createConnectionFormButton').click();
+
+    // delete connection with special characters in alias
+    await page.locator(`#deleteConnBtn_${id}`).click();
+    await page.locator('#deleteConnectionButton').click();
+
+    expect(page.locator('#connectionsButtonsContainer')).toBeEmpty();
+
+  })
+}
+
+for (const {alias, id} of specialAliases) {
+  test(`test connect button for aliases with special chars`, async ({ page }) => {
+    // create default connection
+    await createDefaultConnection(page);
+
+    // create a new connection
+    await page.locator('#createNewConnectiton').click();
+    await page.locator('#connectionName').fill(alias);
+    await page.locator('#createConnectionFormButton').click();
+
+    // connect to default, then connect back to new connection
+    await page.locator('#connBtn_default').click();
+    await page.locator(`#connBtn_${id}`).click();
+
+    await expect(page.locator('.connection-name')).toContainText(alias);
+  })
+}

--- a/ui-tests/tests/widget.test.ts
+++ b/ui-tests/tests/widget.test.ts
@@ -686,7 +686,7 @@ for (const {alias, id} of specialAliases) {
 
     // connect to default, then connect back to new connection
     await page.locator('#connBtn_default').click();
-    await page.locator(`#connBtn_${id}`).click();
+    await page.locator(`#connBtn_${id}`).click(); 
 
     await page.locator(`#connBtn_${id}`).waitFor();
     await expect(page.locator(`#connBtn_${id}`)).toContainText('Connected');

--- a/ui-tests/tests/widget.test.ts
+++ b/ui-tests/tests/widget.test.ts
@@ -692,6 +692,7 @@ for (const {alias, id} of specialAliases) {
     await page.locator('#connBtn_default').click();
     await page.locator(`#connBtn_${id}`).click();
 
-    await expect(page.locator('.connection-name')).toContainText(alias);
+    await page.locator(`#connBtn_${id}`).waitFor();
+    await expect(page.locator(`#connBtn_${id}`)).toContainText('Connected');
   })
 }

--- a/ui-tests/tests/widget.test.ts
+++ b/ui-tests/tests/widget.test.ts
@@ -647,17 +647,13 @@ test('test error if edit connection with existing name', async ({ page }) => {
 });
 
 const specialAliases = [
-  {alias: 'db', id: 'id'},
+  {alias: 'db', id: 'db'},
   {alias: 'db with space', id: 'db_with_space'},
   {alias: 'db?', id: 'db63'},
   {alias: 'db://', id: 'db584747'},
   {alias: 'db! !', id: 'db33_33'},
   {alias: ';db', id: '59db'},
   {alias: ' db', id: '_db'},
-  { 
-    alias: '!@#$%^&*()-_[]{}|;:?<>,./', 
-    id: '33643536379438424041459591931231251245958636062444647'
-  },
 ]
 
 for (const {alias, id} of specialAliases) {

--- a/ui-tests/tests/widget.test.ts
+++ b/ui-tests/tests/widget.test.ts
@@ -661,7 +661,7 @@ const specialAliases = [
 ]
 
 for (const {alias, id} of specialAliases) {
-  test(`test delete button for aliases with special chars`, async ({ page }) => {
+  test(`test delete button for aliases with special chars: ${alias}`, async ({ page }) => {
     // create a new connection
     await page.locator('#createNewConnection').click();
     await page.locator('#connectionName').fill(alias);
@@ -677,7 +677,7 @@ for (const {alias, id} of specialAliases) {
 }
 
 for (const {alias, id} of specialAliases) {
-  test(`test connect button for aliases with special chars`, async ({ page }) => {
+  test(`test connect button for aliases with special chars: ${alias}`, async ({ page }) => {
     // create default connection
     await createDefaultConnection(page);
 


### PR DESCRIPTION
## Describe your changes
- Fixed bug that broke `connect` and `delete` button in `ConnectorWidget` when special characters were included in the alias:
  - In `src/widgets/connector.ts`, each connection's alias was being used in the ID for its `connect` and `delete` buttons. When special characters were included in the alias, this caused an exception when `document.querySelector` was called on the ID.
  - To fix, I added `src/util/helper-functions.ts` to hold a string formatting function for special characters. This will replace special characters with their ASCII values (e.g. ':' -> '58'). I applied this function to the ID's for each connection's `connect` and `delete` buttons. Now when `querySelector` is called, the ID is always a valid selector.

## Issue number

Closes #54 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)
