### PR TITLE
#78 Increase playwright test timeout to make CI more reliable

### DIFF
--- a/ui-tests/playwright.config.js
+++ b/ui-tests/playwright.config.js
@@ -5,6 +5,7 @@ const baseConfig = require('@jupyterlab/galata/lib/playwright-config');
 
 module.exports = {
   ...baseConfig,
+  timeout: 120 * 1000,
   webServer: {
     command: 'jlpm start',
     url: 'http://localhost:8888/lab',


### PR DESCRIPTION
## Describe your changes

Increase playwright test timeout to make CI more reliable. This is going to make them slower as well.
We should fix the underlying issue.

## Issue number

Closes #78 

## Checklist before requesting a review

- [x] Performed a self-review of my code
- [x] Formatted my code with [`pkgmt format`](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#linting-formatting)
- [x] Added [tests](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#testing) (when necessary).
- [x] Added [docstring](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#documenting-changes-and-new-features) documentation and update the [changelog](https://ploomber-contributing.readthedocs.io/en/latest/contributing/pr.html#changelog) (when needed)
